### PR TITLE
fix depreciation warnings

### DIFF
--- a/pyexcel_xlsx/__init__.py
+++ b/pyexcel_xlsx/__init__.py
@@ -47,13 +47,13 @@ class XLSXSheet(SheetReader):
         """
         Number of rows in the xls sheet
         """
-        return self.native_sheet.get_highest_row()
+        return self.native_sheet.max_row
 
     def number_of_columns(self):
         """
         Number of columns in the xls sheet
         """
-        return self.native_sheet.get_highest_column()
+        return self.native_sheet.max_column
 
     def cell_value(self, row, column):
         """


### PR DESCRIPTION
```python
openpyxl/worksheet/worksheet.py:377:
UserWarning: Call to deprecated function or class get_highest_column
(Use the max_column propery.).

openpyxl/worksheet/worksheet.py:350:
UserWarning: Call to deprecated function or class get_highest_row
(Use the max_row property).
```

Looks like they've been depreciated for awhile, but I'm only just now seeing the warnings:
https://bitbucket.org/openpyxl/openpyxl/annotate/59d472f008dbbe2f99c487879709204115090e93/openpyxl/worksheet/worksheet.py?at=default&fileviewer=file-view-default#worksheet.py-349